### PR TITLE
Updates for Frontier

### DIFF
--- a/.github/workflows/apptainer_exachem_mpich.yaml
+++ b/.github/workflows/apptainer_exachem_mpich.yaml
@@ -61,7 +61,7 @@ jobs:
               cc: gcc
               ga_runtime: MPI_PROGRESS_RANK
               ubuntu: noble
-              gpu: amd_gfx90a_rocm5.7.1
+              gpu: amd_gfx90a_rocm6.2.4
               exachem_branch: main
               tamm_branch: main
               folder: apptainer.mpich

--- a/.github/workflows/apptainer_exachem_mpich.yaml
+++ b/.github/workflows/apptainer_exachem_mpich.yaml
@@ -42,10 +42,6 @@ jobs:
             - MPI_PROGRESS_RANK
           gpu:
             - cpu
-            - amd_gfx90a_rocm6.3.2
-            - amd_gfx90a_rocm6.2.4
-            - amd_gfx90a_rocm6.1.3
-            - amd_gfx90a_rocm5.7.1
             - nvidia_70
             - nvidia_80
           ubuntu:
@@ -55,6 +51,30 @@ jobs:
           elpa:
             - n
           include:
+            - mpich: 3.4.2
+              mpich_device: ch4:ofi
+              ofi: builtin
+              cc: gcc
+              ga_runtime: MPI_PROGRESS_RANK
+              ubuntu: noble
+              gpu: cpu
+              exachem_branch: main
+              tamm_branch: main
+              folder: apptainer.mpich
+              scalapack: y
+              elpa: y
+            - mpich: 3.4.2
+              mpich_device: ch4:ofi
+              ofi: git
+              cc: gcc
+              ga_runtime: MPI_PROGRESS_RANK
+              ubuntu: noble
+              gpu: cpu
+              exachem_branch: main
+              tamm_branch: main
+              folder: apptainer.mpich
+              scalapack: y
+              elpa: y
             - mpich: 3.4.2
               mpich_device: ch4:ofi
               ofi: builtin

--- a/.github/workflows/apptainer_exachem_mpich.yaml
+++ b/.github/workflows/apptainer_exachem_mpich.yaml
@@ -44,10 +44,8 @@ jobs:
             - cpu
             - amd_gfx90a_rocm6.3.2
             - amd_gfx90a_rocm6.2.4
-            - amd_gfx90a_rocm6.2
             - amd_gfx90a_rocm6.1.3
             - amd_gfx90a_rocm5.7.1
-            - amd_gfx90a_rocm5.6
             - nvidia_70
             - nvidia_80
           ubuntu:
@@ -57,6 +55,30 @@ jobs:
           elpa:
             - n
           include:
+            - mpich: 3.4.2
+              mpich_device: ch4:ofi
+              ofi: builtin
+              cc: gcc
+              ga_runtime: MPI_PROGRESS_RANK
+              ubuntu: noble
+              gpu: amd_gfx90a_rocm5.7.1
+              exachem_branch: main
+              tamm_branch: main
+              folder: apptainer.mpich
+              scalapack: y
+              elpa: n
+            - mpich: 3.4.2
+              mpich_device: ch4:ofi
+              ofi: builtin
+              cc: gcc
+              ga_runtime: MPI_PROGRESS_RANK
+              ubuntu: noble
+              gpu: amd_gfx90a_rocm6.3.2
+              exachem_branch: main
+              tamm_branch: main
+              folder: apptainer.mpich
+              scalapack: y
+              elpa: n
             - mpich: main
               mpich_device: ch4:ofi
               ofi: builtin

--- a/apptainer.mpich/Singularity
+++ b/apptainer.mpich/Singularity
@@ -186,7 +186,9 @@ fi \
     wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor | tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null 
     echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | tee /etc/apt/sources.list.d/oneAPI.list
    wget -qO - https://repositories.intel.com/gpu/intel-graphics.key |  gpg --yes --dearmor --output /usr/share/keyrings/intel-graphics.gpg
-   echo "deb [arch=amd64 signed-by=/usr/share/keyrings/intel-graphics.gpg] https://repositories.intel.com/gpu/ubuntu "${UBUNTU_VERSION}"/lts/2350 unified" | \
+   echo "UBUNTU_VERSION is " ${UBUNTU_VERSION}
+   echo "UBUNTU_CODE is " ${UBUNTU_CODE}
+   echo "deb [arch=amd64 signed-by=/usr/share/keyrings/intel-graphics.gpg] https://repositories.intel.com/gpu/ubuntu "${UBUNTU_CODE}"/lts/2350 unified" | \
     tee /etc/apt/sources.list.d/intel-gpu-${UBUNTU_VERSION}.list
     apt-get update
     apt-get install -y  \

--- a/apptainer.mpich/Singularity
+++ b/apptainer.mpich/Singularity
@@ -186,7 +186,7 @@ fi \
     wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor | tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null 
     echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | tee /etc/apt/sources.list.d/oneAPI.list
    wget -qO - https://repositories.intel.com/gpu/intel-graphics.key |  gpg --yes --dearmor --output /usr/share/keyrings/intel-graphics.gpg
-   echo "deb [arch=amd64 signed-by=/usr/share/keyrings/intel-graphics.gpg] https://repositories.intel.com/gpu/ubuntu ${UBUNTU_VERSION}/lts/2350 unified" | \
+   echo "deb [arch=amd64 signed-by=/usr/share/keyrings/intel-graphics.gpg] https://repositories.intel.com/gpu/ubuntu "${UBUNTU_VERSION}"/lts/2350 unified" | \
     tee /etc/apt/sources.list.d/intel-gpu-${UBUNTU_VERSION}.list
     apt-get update
     apt-get install -y  \

--- a/apptainer.mpich/Singularity
+++ b/apptainer.mpich/Singularity
@@ -186,8 +186,8 @@ fi \
     wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor | tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null 
     echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | tee /etc/apt/sources.list.d/oneAPI.list
    wget -qO - https://repositories.intel.com/gpu/intel-graphics.key |  gpg --yes --dearmor --output /usr/share/keyrings/intel-graphics.gpg
-   echo "deb [arch=amd64 signed-by=/usr/share/keyrings/intel-graphics.gpg] https://repositories.intel.com/gpu/ubuntu jammy/lts/2350 unified" | \
-    tee /etc/apt/sources.list.d/intel-gpu-jammy.list
+   echo "deb [arch=amd64 signed-by=/usr/share/keyrings/intel-graphics.gpg] https://repositories.intel.com/gpu/ubuntu ${UBUNTU_VERSION}/lts/2350 unified" | \
+    tee /etc/apt/sources.list.d/intel-gpu-${UBUNTU_VERSION}.list
     apt-get update
     apt-get install -y  \
     libigc-dev intel-igc-cm libigdfcl-dev libigfxcmrt-dev level-zero-dev xpu-smi


### PR DESCRIPTION
* Build images with Ubuntu noble to get glibc>=2.38 (now in use on Frontier)